### PR TITLE
add a space if there is a name before a prefixed string

### DIFF
--- a/minimizer.py
+++ b/minimizer.py
@@ -62,9 +62,11 @@ class TokenGroup(object):
 			if tok[0] != NEWLINE and tok[0] != NL:
 				if len(prev) != 0:
 					if rmwspace:
+						is_prefixed_string = tok[0] == STRING and not tok[1].startswith(('\'', '"'))
 						if (prev[0] in (NAME, NUMBER) and tok[0] in (NAME, NUMBER)) or \
 							 (prev[0] == OP and tok[1] in self._WORD_OPS) or \
-							 (tok[0] in (OP, STRING) and prev[1] in self._WORD_OPS):
+							 (tok[0] in (OP, STRING) and prev[1] in self._WORD_OPS) or \
+							 (prev[0] == NAME and is_prefixed_string):
 							ret = ''.join([ret, wspace_char])
 					else:
 						# tok[2][1]: start column, prev[3][1]: end column


### PR DESCRIPTION
Hey man,

I noticed there is is problem minimizing code with prefixed strings in it (not sure if that's the right term for it, but what I mean by "prefixed" strings is strings like b"hello").

For example:
```
if b"hello" == a:
    pass
```
Will get minimized to 
```
ifb"hello"==a:
    pass
```

I have my attempt at a fix so feel free to use it if you want.